### PR TITLE
Declare libc Version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ name = "polydraw"
 version = "0.0.1"
 
 [dependencies]
-libc = "*"
+libc = "0.1"


### PR DESCRIPTION
Because of breaking changes on current libc Version 0.2 (see
https://users.rust-lang.org/t/the-libc-crate-is-now-at-v0-2-0/3509)
